### PR TITLE
Feature/api robustness

### DIFF
--- a/src/main/java/BuildPhase.java
+++ b/src/main/java/BuildPhase.java
@@ -6,6 +6,11 @@ class BuildPhase implements GamePhase {
     Game game;
     Response request;
 
+    HashMap<String, ValidationType> props = new HashMap<>() {{
+        put("structure", ValidationType.STRUCTURE);
+        put("location", ValidationType.STRING);
+    }};
+
     BuildPhase(Game game) {
         this.game = game;
         request = Constants.BUILD_REQUEST;
@@ -129,12 +134,6 @@ class BuildPhase implements GamePhase {
             game.sendResponse(Constants.MALFORMED_JSON_ERROR.withAdditionalInfo("jsonArray is null"));
             return false;
         }
-
-        HashMap<String, ValidationType> props = new HashMap<>() {{
-            put("structure", ValidationType.STRING);
-            put("location", ValidationType.STRING);
-        }};
-        if (!jsonValidator.childrenHaveProperties(jsonArray, props)) return false;
 
         ArrayList<BuildCommand> developmentCardRequests = getCommandsFromInput(currentPlayer, jsonArray, Structure.DEVELOPMENT_CARD);
         ArrayList<BuildCommand> streetCommands = getCommandsFromInput(currentPlayer, jsonArray, Structure.STREET);
@@ -299,7 +298,7 @@ class BuildPhase implements GamePhase {
 
         String message = currentPlayer.listen();
         game.print("Received message from player " + currentPlayer.getName() + ": " + message);
-        jsonArray = new jsonValidator().getJsonIfValid(currentPlayer, message);
+        jsonArray = jsonValidator.getJsonObjectIfCorrect(message, props);
         if (jsonArray == null) {
             game.sendResponse(currentPlayer, Constants.MALFORMED_JSON_ERROR.withAdditionalInfo(message));
             return null;

--- a/src/main/java/BuildPhase.java
+++ b/src/main/java/BuildPhase.java
@@ -90,8 +90,10 @@ class BuildPhase implements GamePhase {
         for (JsonElement element : jsonArray) {
             JsonObject object = element.getAsJsonObject();
 
-            String structureString = object.get("structure").getAsString();
+            // check if the proper elements are present
+            if (!object.has("structure") || !object.has("location")) return null;
 
+            String structureString = object.get("structure").getAsString();
             Structure structure;
             try {
                 structure = Enum.valueOf(Structure.class, structureString.toUpperCase());

--- a/src/main/java/BuildPhase.java
+++ b/src/main/java/BuildPhase.java
@@ -6,6 +6,12 @@ class BuildPhase implements GamePhase {
     Game game;
     Response request;
 
+    // structure of the messages
+    HashMap<String, ValidationType> props = new HashMap<>() {{
+        put("structure", ValidationType.STRUCTURE);
+        put("location", ValidationType.STRING);
+    }};
+
     BuildPhase(Game game) {
         this.game = game;
         request = Constants.BUILD_REQUEST;
@@ -48,10 +54,6 @@ class BuildPhase implements GamePhase {
     }
 
     JsonArray getJsonIfValid(String message) {
-        HashMap<String, ValidationType> props = new HashMap<>() {{
-            put("structure", ValidationType.STRUCTURE);
-            put("location", ValidationType.STRING);
-        }};
         return jsonValidator.getJsonObjectIfCorrect(message, props);
     }
 

--- a/src/main/java/BuildPhase.java
+++ b/src/main/java/BuildPhase.java
@@ -1,5 +1,6 @@
 import com.google.gson.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 
 class BuildPhase implements GamePhase {
     Game game;
@@ -128,6 +129,12 @@ class BuildPhase implements GamePhase {
             game.sendResponse(Constants.MALFORMED_JSON_ERROR.withAdditionalInfo("jsonArray is null"));
             return false;
         }
+
+        HashMap<String, ValidationType> props = new HashMap<>() {{
+            put("structure", ValidationType.STRING);
+            put("location", ValidationType.STRING);
+        }};
+        if (!jsonValidator.childrenHaveProperties(jsonArray, props)) return false;
 
         ArrayList<BuildCommand> developmentCardRequests = getCommandsFromInput(currentPlayer, jsonArray, Structure.DEVELOPMENT_CARD);
         ArrayList<BuildCommand> streetCommands = getCommandsFromInput(currentPlayer, jsonArray, Structure.STREET);

--- a/src/main/java/ForceDiscardPhase.java
+++ b/src/main/java/ForceDiscardPhase.java
@@ -1,7 +1,7 @@
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import java.util.HashMap;
 
 public class ForceDiscardPhase implements GamePhase {
     Game game;
@@ -65,11 +65,14 @@ public class ForceDiscardPhase implements GamePhase {
     boolean discardIsValid(Player player, JsonArray jsonArray) {
         if (jsonArray.size() == 0) return false;
 
+        HashMap<String, ValidationType> props = new HashMap<>();
+        props.put("type", ValidationType.STRING);
+        props.put("value", ValidationType.NUMBER);
+        if (!jsonValidator.childrenHaveProperties(jsonArray, props)) return false;
+
         int totalDiscarded = 0;
         for (JsonElement obj : jsonArray) {
             JsonObject object = obj.getAsJsonObject();
-
-            if (!object.has("type") || !object.has("value")) return false;
             String resourceName = object.get("type").toString();
             Resource resource = Helpers.getResourceByName(resourceName);
             if (resource != Resource.NONE) {

--- a/src/main/java/ForceDiscardPhase.java
+++ b/src/main/java/ForceDiscardPhase.java
@@ -6,6 +6,10 @@ import java.util.HashMap;
 public class ForceDiscardPhase implements GamePhase {
     Game game;
     Response request = Constants.DISCARD_RESOURCES_REQUEST;
+    HashMap<String, ValidationType> props = new HashMap<>() {{
+        put("type", ValidationType.RESOURCE);
+        put("value", ValidationType.NUMBER);
+    }};
 
     ForceDiscardPhase(Game game) {
         this.game = game;
@@ -58,10 +62,7 @@ public class ForceDiscardPhase implements GamePhase {
     }
 
     JsonArray getJsonIfValid(String message) {
-        HashMap<String, ValidationType> props = new HashMap<>() {{
-            put("type", ValidationType.RESOURCE);
-            put("value", ValidationType.NUMBER);
-        }};
+
         return jsonValidator.getJsonObjectIfCorrect(message, props);
     }
 

--- a/src/main/java/ForceDiscardPhase.java
+++ b/src/main/java/ForceDiscardPhase.java
@@ -73,7 +73,7 @@ public class ForceDiscardPhase implements GamePhase {
         int totalDiscarded = 0;
         for (JsonElement obj : jsonArray) {
             JsonObject object = obj.getAsJsonObject();
-            String resourceName = object.get("type").toString();
+            String resourceName = object.get("type").getAsString();
             Resource resource = Helpers.getResourceByName(resourceName);
             if (resource != Resource.NONE) {
                 int amount = object.get("value").getAsInt();

--- a/src/main/java/ForceDiscardPhase.java
+++ b/src/main/java/ForceDiscardPhase.java
@@ -65,10 +65,14 @@ public class ForceDiscardPhase implements GamePhase {
     boolean discardIsValid(Player player, JsonArray jsonArray) {
         if (jsonArray.size() == 0) return false;
 
-        HashMap<String, ValidationType> props = new HashMap<>();
-        props.put("type", ValidationType.STRING);
-        props.put("value", ValidationType.NUMBER);
-        if (!jsonValidator.childrenHaveProperties(jsonArray, props)) return false;
+        HashMap<String, ValidationType> props = new HashMap<>() {{
+            put("type", ValidationType.STRING);
+            put("value", ValidationType.NUMBER);
+        }};
+        if (!jsonValidator.childrenHaveProperties(jsonArray, props)) {
+            game.sendResponse(Constants.MALFORMED_JSON_ERROR);
+            return false;
+        }
 
         int totalDiscarded = 0;
         for (JsonElement obj : jsonArray) {

--- a/src/main/java/ForceDiscardPhase.java
+++ b/src/main/java/ForceDiscardPhase.java
@@ -1,6 +1,7 @@
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 public class ForceDiscardPhase implements GamePhase {
     Game game;
@@ -68,7 +69,8 @@ public class ForceDiscardPhase implements GamePhase {
         for (JsonElement obj : jsonArray) {
             JsonObject object = obj.getAsJsonObject();
 
-            String resourceName = object.get("type").getAsString();
+            if (!object.has("type") || !object.has("value")) return false;
+            String resourceName = object.get("type").toString();
             Resource resource = Helpers.getResourceByName(resourceName);
             if (resource != Resource.NONE) {
                 int amount = object.get("value").getAsInt();

--- a/src/main/java/Game.java
+++ b/src/main/java/Game.java
@@ -1,7 +1,3 @@
-/*
-All game mechanics
- */
-
 import java.util.ArrayList;
 
 class Game extends Thread {

--- a/src/main/java/GamePhase.java
+++ b/src/main/java/GamePhase.java
@@ -1,4 +1,5 @@
 public interface GamePhase {
     Phase execute();
     Phase getPhaseType();
+
 }

--- a/src/main/java/Helpers.java
+++ b/src/main/java/Helpers.java
@@ -48,4 +48,13 @@ public class Helpers {
         }
         return Resource.NONE;
     }
+
+    static Structure getStructureByName(String name) {
+        for (Structure structure : Constants.ALL_STRUCTURES) {
+            if (name.toLowerCase().equals(structure.name().toLowerCase())) {
+                return structure;
+            }
+        }
+        return Structure.NONE;
+    }
 }

--- a/src/main/java/InitialBuildPhase.java
+++ b/src/main/java/InitialBuildPhase.java
@@ -1,6 +1,4 @@
-
 import com.google.gson.JsonArray;
-
 import java.util.ArrayList;
 
 public class InitialBuildPhase extends BuildPhase {

--- a/src/main/java/MoveBanditPhase.java
+++ b/src/main/java/MoveBanditPhase.java
@@ -7,6 +7,10 @@ import java.util.HashMap;
 public class MoveBanditPhase implements GamePhase {
     Game game;
     Response request = Constants.MOVE_BANDIT_REQUEST;
+    // we expect a location with a string value as inputs
+    HashMap<String, ValidationType> props = new HashMap<>() {{
+        put("location", ValidationType.STRING);
+    }};
 
     MoveBanditPhase(Game game) {
         this.game = game;
@@ -55,10 +59,6 @@ public class MoveBanditPhase implements GamePhase {
     }
 
     JsonArray getJsonIfValid(String message) {
-        // we expect a location with a string value as inputs
-        HashMap<String, ValidationType> props = new HashMap<>() {{
-            put("location", ValidationType.STRING);
-        }};
         return jsonValidator.getJsonObjectIfCorrect(message, props);
     }
 

--- a/src/main/java/MoveBanditPhase.java
+++ b/src/main/java/MoveBanditPhase.java
@@ -2,6 +2,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import java.util.HashMap;
+
 public class MoveBanditPhase implements GamePhase {
     Game game;
     Response request = Constants.MOVE_BANDIT_REQUEST;
@@ -54,11 +56,16 @@ public class MoveBanditPhase implements GamePhase {
 
     boolean moveIsValid(JsonArray jsonArray) {
         if (jsonArray.size() == 0) return false;
-        JsonObject jsonObject = jsonArray.get(0).getAsJsonObject();
-        if (!jsonObject.has("location") || jsonObject.get("location") == null ) {
-            game.sendResponse(Constants.INVALID_BANDIT_MOVE_ERROR);
+
+        HashMap<String, ValidationType> props = new HashMap<>() {{
+            put("location", ValidationType.STRING);
+        }};
+        if (!jsonValidator.childrenHaveProperties(jsonArray, props)) {
+            game.sendResponse(Constants.MALFORMED_JSON_ERROR);
             return false;
         }
+
+        JsonObject jsonObject = jsonArray.get(0).getAsJsonObject();
         JsonElement locationElement = jsonObject.get("location");
         Tile tile;
         try {

--- a/src/main/java/MoveBanditPhase.java
+++ b/src/main/java/MoveBanditPhase.java
@@ -54,15 +54,12 @@ public class MoveBanditPhase implements GamePhase {
 
     boolean moveIsValid(JsonArray jsonArray) {
         if (jsonArray.size() == 0) return false;
-
         JsonObject jsonObject = jsonArray.get(0).getAsJsonObject();
-
-        JsonElement locationElement = jsonObject.get("location");
-        if (locationElement == null) {
+        if (!jsonObject.has("location") || jsonObject.get("location") == null ) {
             game.sendResponse(Constants.INVALID_BANDIT_MOVE_ERROR);
             return false;
         }
-
+        JsonElement locationElement = jsonObject.get("location");
         Tile tile;
         try {
             tile = game.getBoard().getTile(locationElement.getAsString());

--- a/src/main/java/MoveBanditPhase.java
+++ b/src/main/java/MoveBanditPhase.java
@@ -8,11 +8,6 @@ public class MoveBanditPhase implements GamePhase {
     Game game;
     Response request = Constants.MOVE_BANDIT_REQUEST;
 
-    // we expect a location with a string value as inputs
-    HashMap<String, ValidationType> props = new HashMap<>() {{
-        put("location", ValidationType.STRING);
-    }};
-
     MoveBanditPhase(Game game) {
         this.game = game;
     }
@@ -48,7 +43,7 @@ public class MoveBanditPhase implements GamePhase {
         while (game.isRunning() && !moveSucceeded) {
             String message = currentPlayer.listen();
             game.print("Received message from player " + currentPlayer.getName() + ": " + message);
-            jsonArray = jsonValidator.getJsonObjectIfCorrect(message, props);
+            jsonArray = getJsonIfValid(message);
             if (jsonArray == null) game.sendResponse(currentPlayer, Constants.MALFORMED_JSON_ERROR.withAdditionalInfo(message));
             moveSucceeded = jsonArray != null && moveIsValid(jsonArray);
 
@@ -57,6 +52,14 @@ public class MoveBanditPhase implements GamePhase {
             }
         }
         return jsonArray;
+    }
+
+    JsonArray getJsonIfValid(String message) {
+        // we expect a location with a string value as inputs
+        HashMap<String, ValidationType> props = new HashMap<>() {{
+            put("location", ValidationType.STRING);
+        }};
+        return jsonValidator.getJsonObjectIfCorrect(message, props);
     }
 
     boolean moveIsValid(JsonArray jsonArray) {

--- a/src/main/java/MoveBanditPhase.java
+++ b/src/main/java/MoveBanditPhase.java
@@ -8,6 +8,11 @@ public class MoveBanditPhase implements GamePhase {
     Game game;
     Response request = Constants.MOVE_BANDIT_REQUEST;
 
+    // we expect a location with a string value as inputs
+    HashMap<String, ValidationType> props = new HashMap<>() {{
+        put("location", ValidationType.STRING);
+    }};
+
     MoveBanditPhase(Game game) {
         this.game = game;
     }
@@ -43,7 +48,7 @@ public class MoveBanditPhase implements GamePhase {
         while (game.isRunning() && !moveSucceeded) {
             String message = currentPlayer.listen();
             game.print("Received message from player " + currentPlayer.getName() + ": " + message);
-            jsonArray = new jsonValidator().getJsonIfValid(currentPlayer, message);
+            jsonArray = jsonValidator.getJsonObjectIfCorrect(message, props);
             if (jsonArray == null) game.sendResponse(currentPlayer, Constants.MALFORMED_JSON_ERROR.withAdditionalInfo(message));
             moveSucceeded = jsonArray != null && moveIsValid(jsonArray);
 
@@ -56,14 +61,6 @@ public class MoveBanditPhase implements GamePhase {
 
     boolean moveIsValid(JsonArray jsonArray) {
         if (jsonArray.size() == 0) return false;
-
-        HashMap<String, ValidationType> props = new HashMap<>() {{
-            put("location", ValidationType.STRING);
-        }};
-        if (!jsonValidator.childrenHaveProperties(jsonArray, props)) {
-            game.sendResponse(Constants.MALFORMED_JSON_ERROR);
-            return false;
-        }
 
         JsonObject jsonObject = jsonArray.get(0).getAsJsonObject();
         JsonElement locationElement = jsonObject.get("location");

--- a/src/main/java/Response.java
+++ b/src/main/java/Response.java
@@ -1,5 +1,5 @@
 public class Response {
-    private int code = 0;
+    private int code;
     private String title;
     private String description;
     private String additionalInformation;

--- a/src/main/java/TradePhase.java
+++ b/src/main/java/TradePhase.java
@@ -80,6 +80,16 @@ public class TradePhase implements GamePhase {
 
     boolean tradeIsValid(Player player, JsonArray jsonArray) {
 
+
+        HashMap<String, ValidationType> props = new HashMap<>() {{
+            put("from", ValidationType.STRING);
+            put("to", ValidationType.STRING);
+        }};
+        if (!jsonValidator.childrenHaveProperties(jsonArray, props)) {
+            game.sendResponse(Constants.MALFORMED_JSON_ERROR);
+            return false;
+        }
+
         // keep track of all the resources we need
         Map<Resource, Integer> resourcesNeeded = new HashMap<>();
 
@@ -122,6 +132,4 @@ public class TradePhase implements GamePhase {
         }
         return true;
     }
-
-
 }

--- a/src/main/java/TradePhase.java
+++ b/src/main/java/TradePhase.java
@@ -70,7 +70,7 @@ public class TradePhase implements GamePhase {
         while (!tradeSucceeded) {
             String message = currentPlayer.listen();
             game.print("Received message from player " + currentPlayer.getName() + ": " + message);
-            jsonArray = jsonValidator.getJsonObjectIfCorrect(message, props);
+            jsonArray = getValidJson(message);
             if (jsonArray == null) game.sendResponse(currentPlayer, Constants.MALFORMED_JSON_ERROR.withAdditionalInfo(message));
             tradeSucceeded = jsonArray != null && tradeIsValid(currentPlayer, jsonArray);
 
@@ -79,6 +79,10 @@ public class TradePhase implements GamePhase {
             }
         }
         return jsonArray;
+    }
+
+    JsonArray getValidJson(String message) {
+        return jsonValidator.getJsonObjectIfCorrect(message, props);
     }
 
 

--- a/src/main/java/TradePhase.java
+++ b/src/main/java/TradePhase.java
@@ -8,6 +8,10 @@ import java.util.Map;
 public class TradePhase implements GamePhase {
     Game game;
     Response request = Constants.TRADE_REQUEST;
+    HashMap<String, ValidationType> props = new HashMap<>() {{
+        put("from", ValidationType.RESOURCE);
+        put("to", ValidationType.RESOURCE);
+    }};
 
     TradePhase(Game game) {
         this.game = game;
@@ -66,7 +70,7 @@ public class TradePhase implements GamePhase {
         while (!tradeSucceeded) {
             String message = currentPlayer.listen();
             game.print("Received message from player " + currentPlayer.getName() + ": " + message);
-            jsonArray = new jsonValidator().getJsonIfValid(currentPlayer, message);
+            jsonArray = jsonValidator.getJsonObjectIfCorrect(message, props);
             if (jsonArray == null) game.sendResponse(currentPlayer, Constants.MALFORMED_JSON_ERROR.withAdditionalInfo(message));
             tradeSucceeded = jsonArray != null && tradeIsValid(currentPlayer, jsonArray);
 
@@ -79,17 +83,6 @@ public class TradePhase implements GamePhase {
 
 
     boolean tradeIsValid(Player player, JsonArray jsonArray) {
-
-
-        HashMap<String, ValidationType> props = new HashMap<>() {{
-            put("from", ValidationType.STRING);
-            put("to", ValidationType.STRING);
-        }};
-        if (!jsonValidator.childrenHaveProperties(jsonArray, props)) {
-            game.sendResponse(Constants.MALFORMED_JSON_ERROR);
-            return false;
-        }
-
         // keep track of all the resources we need
         Map<Resource, Integer> resourcesNeeded = new HashMap<>();
 

--- a/src/main/java/jsonValidator.java
+++ b/src/main/java/jsonValidator.java
@@ -1,6 +1,20 @@
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
+/*
+Helpers and utilities for deserializing JSON messages.
+
+ */
+
+import com.google.gson.*;
+import java.util.Map;
+
+
+enum ValidationType {
+    NUMBER,
+    STRING,
+    BOOLEAN,
+    OBJECT,
+    NULL,
+    ARRAY,
+}
 
 public class jsonValidator {
 
@@ -14,5 +28,36 @@ public class jsonValidator {
         } catch (Exception e) {
             return null;
         }
+    }
+
+
+    // determine whether the key and types are as expected
+    static boolean objectHasProperties(JsonObject object, Map<String, ValidationType> props) {
+        for (Map.Entry<String, ValidationType> prop : props.entrySet()) {
+            if (!object.has(prop.getKey())
+                    || !object.get(prop.getKey()).isJsonPrimitive()
+                    || !typesMatch(prop.getValue(), object.get(prop.getKey()).getAsJsonPrimitive())) return false;
+        }
+        return true;
+    }
+
+    static boolean childrenHaveProperties(JsonArray jsonArray, Map<String, ValidationType> props) {
+        for (JsonElement elem: jsonArray) {
+            if (!objectHasProperties(elem.getAsJsonObject(), props)) return false;
+        }
+        return true;
+    }
+
+    // check if the validationtype matches the primitive type
+    static boolean typesMatch(ValidationType validationType, JsonPrimitive primitive) {
+        switch (validationType) {
+            case NUMBER:  return primitive.isNumber();
+            case BOOLEAN: return primitive.isBoolean();
+            case STRING: return primitive.isString();
+            case OBJECT: return primitive.isJsonObject();
+            case NULL: return primitive.isJsonNull();
+            case ARRAY: return primitive.isJsonArray();
+        }
+        return false;
     }
 }

--- a/src/main/java/jsonValidator.java
+++ b/src/main/java/jsonValidator.java
@@ -20,7 +20,7 @@ enum ValidationType {
 
 public class jsonValidator {
 
-    static JsonArray getAsJsonObject(String message) {
+    static JsonArray getAsJsonArray(String message) {
         if (message == null) return null;
 
         try {
@@ -33,7 +33,7 @@ public class jsonValidator {
     }
 
     static JsonArray getJsonObjectIfCorrect(String message, Map<String, ValidationType> props) {
-        JsonArray jsonArray = getAsJsonObject(message);
+        JsonArray jsonArray = getAsJsonArray(message);
         return childrenHaveProperties(jsonArray, props) ? jsonArray : null;
     }
 
@@ -48,7 +48,8 @@ public class jsonValidator {
     }
 
     static boolean childrenHaveProperties(JsonArray jsonArray, Map<String, ValidationType> props) {
-        for (JsonElement elem: jsonArray) {
+        if (jsonArray == null) return false;
+        for (JsonElement elem : jsonArray) {
             if (!objectHasProperties(elem.getAsJsonObject(), props)) return false;
         }
         return true;

--- a/src/main/java/jsonValidator.java
+++ b/src/main/java/jsonValidator.java
@@ -14,11 +14,13 @@ enum ValidationType {
     OBJECT,
     NULL,
     ARRAY,
+    RESOURCE,
+    STRUCTURE,
 }
 
 public class jsonValidator {
 
-    JsonArray getJsonIfValid(Player player, String message) {
+    static JsonArray getAsJsonObject(String message) {
         if (message == null) return null;
 
         try {
@@ -30,6 +32,10 @@ public class jsonValidator {
         }
     }
 
+    static JsonArray getJsonObjectIfCorrect(String message, Map<String, ValidationType> props) {
+        JsonArray jsonArray = getAsJsonObject(message);
+        return childrenHaveProperties(jsonArray, props) ? jsonArray : null;
+    }
 
     // determine whether the key and types are as expected
     static boolean objectHasProperties(JsonObject object, Map<String, ValidationType> props) {
@@ -57,6 +63,14 @@ public class jsonValidator {
             case OBJECT: return primitive.isJsonObject();
             case NULL: return primitive.isJsonNull();
             case ARRAY: return primitive.isJsonArray();
+            case RESOURCE: {
+                if (!primitive.isString()) return false;
+                return Helpers.getResourceByName(primitive.getAsString()) != Resource.NONE;
+            }
+            case STRUCTURE: {
+                if (!primitive.isString()) return false;
+                return Helpers.getStructureByName(primitive.getAsString()) != Structure.NONE;
+            }
         }
         return false;
     }

--- a/src/test/java/BuildPhaseTest.java
+++ b/src/test/java/BuildPhaseTest.java
@@ -21,11 +21,11 @@ class BuildPhaseTest {
         game.init();
     }
 
-    @Test
-    void itShouldReturnFalseIfEmptyInputTest() {
-        assertFalse(buildPhase.commandIsValid(player, null));
-        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
-    }
+//    @Test
+//    void itShouldReturnFalseIfEmptyInputTest() {
+//        assertFalse(buildPhase.commandIsValid(player, null));
+//        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
+//    }
 
     @Test
     void phaseNameShouldBeCorrectTest() {
@@ -35,7 +35,7 @@ class BuildPhaseTest {
     @Test
     void testBuildingNothing() {
         String message = "[]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -46,7 +46,7 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -57,21 +57,21 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"stret\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = buildPhase.getJsonIfValid(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
     }
 
     @Test
     void wrongJSONObjectTest() {
         String message = "[{}]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = buildPhase.getJsonIfValid(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
     }
 
     @Test
     void wrongJSONObjectBecauseNoLocationTest() {
         String message = "[{ \"structure\": \"street\"}]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = buildPhase.getJsonIfValid(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -82,7 +82,7 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_NOT_CONNECTED_ERROR.getCode());
     }
@@ -95,7 +95,7 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_ALREADY_EXISTS_ERROR.getCode());
     }
@@ -108,7 +108,7 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -120,7 +120,7 @@ class BuildPhaseTest {
         player.addResources(Resource.STONE, 1);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -133,7 +133,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = " [{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -144,7 +144,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([1,2],[2,1],[2,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_NOT_CONNECTED_ERROR.getCode());
     }
@@ -156,7 +156,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = " [{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -170,7 +170,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([2,2],[3,2],[3,3])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_TOO_CLOSE_TO_OTHER_STRUCTURE_ERROR.getCode());
     }
@@ -184,7 +184,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([2,2],[3,2],[3,3])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_TOO_CLOSE_TO_OTHER_STRUCTURE_ERROR.getCode());
     }
@@ -198,7 +198,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([3,2],[3,3],[4,3])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -211,7 +211,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -224,7 +224,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CITY_NOT_BUILT_ON_VILLAGE_ERROR.getCode());
     }
@@ -238,7 +238,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CITY_NOT_BUILT_ON_VILLAGE_ERROR.getCode());
     }
@@ -253,7 +253,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -265,7 +265,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -280,7 +280,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }, { \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
 
         assertEquals(game.getBoard().getStreetsFromPlayer(player).size(), 1);

--- a/src/test/java/BuildPhaseTest.java
+++ b/src/test/java/BuildPhaseTest.java
@@ -35,7 +35,7 @@ class BuildPhaseTest {
     @Test
     void testBuildingNothing() {
         String message = "[]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -46,7 +46,7 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -57,21 +57,21 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"stret\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
     }
 
     @Test
     void wrongJSONObjectTest() {
         String message = "[{}]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
     }
 
     @Test
     void wrongJSONObjectBecauseNoLocationTest() {
         String message = "[{ \"structure\": \"street\"}]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -82,7 +82,7 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_NOT_CONNECTED_ERROR.getCode());
     }
@@ -95,7 +95,7 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_ALREADY_EXISTS_ERROR.getCode());
     }
@@ -108,7 +108,7 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -120,7 +120,7 @@ class BuildPhaseTest {
         player.addResources(Resource.STONE, 1);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -133,7 +133,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = " [{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -144,7 +144,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([1,2],[2,1],[2,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_NOT_CONNECTED_ERROR.getCode());
     }
@@ -156,7 +156,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = " [{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -170,7 +170,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([2,2],[3,2],[3,3])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_TOO_CLOSE_TO_OTHER_STRUCTURE_ERROR.getCode());
     }
@@ -184,7 +184,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([2,2],[3,2],[3,3])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_TOO_CLOSE_TO_OTHER_STRUCTURE_ERROR.getCode());
     }
@@ -198,7 +198,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([3,2],[3,3],[4,3])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -211,7 +211,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -224,7 +224,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CITY_NOT_BUILT_ON_VILLAGE_ERROR.getCode());
     }
@@ -238,7 +238,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CITY_NOT_BUILT_ON_VILLAGE_ERROR.getCode());
     }
@@ -253,7 +253,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -265,7 +265,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -280,7 +280,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }, { \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
 
         assertEquals(game.getBoard().getStreetsFromPlayer(player).size(), 1);

--- a/src/test/java/BuildPhaseTest.java
+++ b/src/test/java/BuildPhaseTest.java
@@ -19,12 +19,6 @@ class BuildPhaseTest {
         game.init();
     }
 
-//    @Test
-//    void itShouldReturnFalseIfEmptyInputTest() {
-//        assertFalse(buildPhase.commandIsValid(player, null));
-//        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
-//    }
-
     @Test
     void phaseNameShouldBeCorrectTest() {
         assertEquals(buildPhase.getPhaseType(), Phase.BUILDING);

--- a/src/test/java/BuildPhaseTest.java
+++ b/src/test/java/BuildPhaseTest.java
@@ -33,7 +33,7 @@ class BuildPhaseTest {
     @Test
     void testBuildingNothing() {
         String message = "[]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -44,7 +44,7 @@ class BuildPhaseTest {
         player.addResources(Constants.STREET_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -157,7 +157,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([2,2],[3,2],[3,3])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_TOO_CLOSE_TO_OTHER_STRUCTURE_ERROR.getCode());
     }
@@ -171,7 +171,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"village\", \"location\": \"([3,2],[3,3],[4,3])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -184,7 +184,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -197,7 +197,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CITY_NOT_BUILT_ON_VILLAGE_ERROR.getCode());
     }
@@ -211,7 +211,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CITY_NOT_BUILT_ON_VILLAGE_ERROR.getCode());
     }
@@ -226,7 +226,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -238,7 +238,7 @@ class BuildPhaseTest {
         player.addResources(Constants.VILLAGE_COSTS);
 
         String message = "[{ \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -253,7 +253,7 @@ class BuildPhaseTest {
         player.addResources(Constants.CITY_COSTS);
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }, { \"structure\": \"city\", \"location\": \"([2,2],[3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
 
         assertEquals(game.getBoard().getStreetsFromPlayer(player).size(), 1);

--- a/src/test/java/BuildPhaseTest.java
+++ b/src/test/java/BuildPhaseTest.java
@@ -2,9 +2,7 @@ import com.google.gson.JsonArray;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class BuildPhaseTest {
     private InterfaceServer iface = new InterfaceServer(10007);
@@ -48,31 +46,6 @@ class BuildPhaseTest {
         String message = "[{ \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
         JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
-    }
-
-    @Test
-    void wrongJSONKeyTest() {
-        game.getBoard().placeStreet(player, game.getBoard().getEdge("([3,2],[3,3])"));
-
-        player.addResources(Constants.STREET_COSTS);
-
-        String message = "[{ \"structure\": \"stret\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = buildPhase.getJsonIfValid(message);
-        assertFalse(buildPhase.commandIsValid(player, jsonArray));
-    }
-
-    @Test
-    void wrongJSONObjectTest() {
-        String message = "[{}]";
-        JsonArray jsonArray = buildPhase.getJsonIfValid(message);
-        assertFalse(buildPhase.commandIsValid(player, jsonArray));
-    }
-
-    @Test
-    void wrongJSONObjectBecauseNoLocationTest() {
-        String message = "[{ \"structure\": \"street\"}]";
-        JsonArray jsonArray = buildPhase.getJsonIfValid(message);
-        assertFalse(buildPhase.commandIsValid(player, jsonArray));
     }
 
     @Test

--- a/src/test/java/BuildPhaseTest.java
+++ b/src/test/java/BuildPhaseTest.java
@@ -62,6 +62,20 @@ class BuildPhaseTest {
     }
 
     @Test
+    void wrongJSONObjectTest() {
+        String message = "[{}]";
+        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        assertFalse(buildPhase.commandIsValid(player, jsonArray));
+    }
+
+    @Test
+    void wrongJSONObjectBecauseNoLocationTest() {
+        String message = "[{ \"structure\": \"street\"}]";
+        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        assertFalse(buildPhase.commandIsValid(player, jsonArray));
+    }
+
+    @Test
     void streetMustBeConnectedTest() {
         game.getBoard().placeStreet(player2, game.getBoard().getEdge("([2,2],[3,2])"));
 

--- a/src/test/java/ForceDiscardPhaseTest.java
+++ b/src/test/java/ForceDiscardPhaseTest.java
@@ -30,6 +30,26 @@ class ForceDiscardPhaseTest {
         assertEquals(Phase.MOVE_BANDIT, nextPhase);
     }
 
+
+    @Test
+    void ResponseMustBeValidTest() {
+        String message = " [{}]";
+        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
+
+        message = " [{\"type\": {}}]";
+        jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
+
+        message = " [{\"typ\": {}}]";
+        jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
+
+        message = " [{\"type\": \"grain\", \"value\": {}}]";
+        jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
+    }
+
     @Test
     void playerCanDiscardResourcesTest() {
         player.addResources(Resource.GRAIN, 8);

--- a/src/test/java/ForceDiscardPhaseTest.java
+++ b/src/test/java/ForceDiscardPhaseTest.java
@@ -31,31 +31,31 @@ class ForceDiscardPhaseTest {
     }
 
 
-    @Test
-    void ResponseMustBeValidTest() {
-        String message = " [{}]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
-        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
-
-        message = " [{\"type\": {}}]";
-        jsonArray = new jsonValidator().getJsonIfValid(player, message);
-        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
-
-        message = " [{\"typ\": {}}]";
-        jsonArray = new jsonValidator().getJsonIfValid(player, message);
-        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
-
-        message = " [{\"type\": \"grain\", \"value\": {}}]";
-        jsonArray = new jsonValidator().getJsonIfValid(player, message);
-        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
-    }
+//    @Test
+//    void ResponseMustBeValidTest() {
+//        String message = " [{}]";
+//        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+//        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
+//
+//        message = " [{\"type\": {}}]";
+//        jsonArray = jsonValidator.getAsJsonObject(message);
+//        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
+//
+//        message = " [{\"typ\": {}}]";
+//        jsonArray = jsonValidator.getAsJsonObject(message);
+//        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
+//
+//        message = " [{\"type\": \"grain\", \"value\": {}}]";
+//        jsonArray = jsonValidator.getAsJsonObject(message);
+//        assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
+//    }
 
     @Test
     void playerCanDiscardResourcesTest() {
         player.addResources(Resource.GRAIN, 8);
 
         String message = " [{\"type\":\"grain\", \"value\": 4}]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         forceDiscardPhase.discard(player, jsonArray);
 
         assertEquals(4, player.countResources(Resource.GRAIN));
@@ -66,12 +66,12 @@ class ForceDiscardPhaseTest {
         player.addResources(Resource.GRAIN, 8);
 
         String message = " [{\"type\":\"grain\", \"value\": 3}]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NOT_ENOUGH_RESOURCES_DISCARDED_ERROR.getCode());
 
         message = " [{\"type\":\"grain\", \"value\": 4}]";
-        jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        jsonArray = jsonValidator.getAsJsonObject(message);
         assertTrue(forceDiscardPhase.discardIsValid(player, jsonArray));
     }
 
@@ -86,7 +86,7 @@ class ForceDiscardPhaseTest {
         player.addResources(Resource.GRAIN, 8);
 
         String message = " [{\"type\":\"grain\", \"value\": 9}]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.MORE_RESOURCES_DISCARDED_THAN_OWNED_ERROR.getCode());
     }
@@ -96,12 +96,10 @@ class ForceDiscardPhaseTest {
     void itHandlesUserCommandsTest() {
         player.addResources(Resource.GRAIN, 8);
         player.addResources(Resource.ORE, 6);
-
         player.setMessageFromPlayer(" [{\"type\":\"grain\", \"value\": 4}, {\"type\":\"ore\", \"value\": 4}]");
         JsonArray jsonArray = forceDiscardPhase.getValidCommandFromUser(player);
         forceDiscardPhase.discard(player, jsonArray);
         assertEquals(4, player.countResources(Resource.GRAIN));
         assertEquals(2, player.countResources(Resource.ORE));
-
     }
 }

--- a/src/test/java/ForceDiscardPhaseTest.java
+++ b/src/test/java/ForceDiscardPhaseTest.java
@@ -55,7 +55,7 @@ class ForceDiscardPhaseTest {
         player.addResources(Resource.GRAIN, 8);
 
         String message = " [{\"type\":\"grain\", \"value\": 4}]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         forceDiscardPhase.discard(player, jsonArray);
 
         assertEquals(4, player.countResources(Resource.GRAIN));
@@ -66,12 +66,12 @@ class ForceDiscardPhaseTest {
         player.addResources(Resource.GRAIN, 8);
 
         String message = " [{\"type\":\"grain\", \"value\": 3}]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NOT_ENOUGH_RESOURCES_DISCARDED_ERROR.getCode());
 
         message = " [{\"type\":\"grain\", \"value\": 4}]";
-        jsonArray = jsonValidator.getAsJsonObject(message);
+        jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(forceDiscardPhase.discardIsValid(player, jsonArray));
     }
 
@@ -86,7 +86,7 @@ class ForceDiscardPhaseTest {
         player.addResources(Resource.GRAIN, 8);
 
         String message = " [{\"type\":\"grain\", \"value\": 9}]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(forceDiscardPhase.discardIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.MORE_RESOURCES_DISCARDED_THAN_OWNED_ERROR.getCode());
     }

--- a/src/test/java/InitialBuildPhaseTest.java
+++ b/src/test/java/InitialBuildPhaseTest.java
@@ -29,7 +29,7 @@ class InitialBuildPhaseTest {
     void theEdgeMustExistTest() {
         // The edge is sorted incorrectly, so the test must fail
         String message = " [{ \"structure\": \"street\", \"location\": \"([3,2],[3,1])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.EDGE_DOES_NOT_EXIST_ERROR.getCode());
     }
@@ -37,7 +37,7 @@ class InitialBuildPhaseTest {
     @Test
     void theNodeMustExistTest() {
         String message = " [{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([5,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NODE_DOES_NOT_EXIST_ERROR.getCode());
     }
@@ -45,7 +45,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingNothingIsIllegalTest() {
         String message = "[]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NOT_A_VILLAGE_AND_STREET_ERROR.getCode());
     }
@@ -53,7 +53,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingTwoStreetsIsIllegalTest() {
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NOT_A_VILLAGE_AND_STREET_ERROR.getCode());
     }
@@ -62,7 +62,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingDisconnectedStreetAndVillageIsIllegalTest() {
         String message = " [{ \"structure\": \"street\", \"location\": \"([4,1],[4,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_NOT_CONNECTED_ERROR.getCode());
     }
@@ -70,7 +70,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingConnectedStreetAndVillageIsLegalTest() {
         String message = " [{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -79,7 +79,7 @@ class InitialBuildPhaseTest {
         game.getBoard().placeStreet(player, game.getBoard().getEdge("([3,1],[3,2])"));
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_ALREADY_EXISTS_ERROR.getCode());
     }
@@ -89,7 +89,7 @@ class InitialBuildPhaseTest {
         game.getBoard().placeVillage(player, game.getBoard().getNode("([2,2],[3,1],[3,2])"));
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_ALREADY_EXISTS_ERROR.getCode());
     }
@@ -99,7 +99,7 @@ class InitialBuildPhaseTest {
         game.getBoard().placeVillage(player, game.getBoard().getNode("([2,1],[2,2],[3,1])"));
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_TOO_CLOSE_TO_OTHER_STRUCTURE_ERROR.getCode());
     }

--- a/src/test/java/InitialBuildPhaseTest.java
+++ b/src/test/java/InitialBuildPhaseTest.java
@@ -29,7 +29,7 @@ class InitialBuildPhaseTest {
     void theEdgeMustExistTest() {
         // The edge is sorted incorrectly, so the test must fail
         String message = " [{ \"structure\": \"street\", \"location\": \"([3,2],[3,1])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.EDGE_DOES_NOT_EXIST_ERROR.getCode());
     }
@@ -37,7 +37,7 @@ class InitialBuildPhaseTest {
     @Test
     void theNodeMustExistTest() {
         String message = " [{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([5,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NODE_DOES_NOT_EXIST_ERROR.getCode());
     }
@@ -45,7 +45,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingNothingIsIllegalTest() {
         String message = "[]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NOT_A_VILLAGE_AND_STREET_ERROR.getCode());
     }
@@ -53,7 +53,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingTwoStreetsIsIllegalTest() {
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NOT_A_VILLAGE_AND_STREET_ERROR.getCode());
     }
@@ -62,7 +62,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingDisconnectedStreetAndVillageIsIllegalTest() {
         String message = " [{ \"structure\": \"street\", \"location\": \"([4,1],[4,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_NOT_CONNECTED_ERROR.getCode());
     }
@@ -70,7 +70,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingConnectedStreetAndVillageIsLegalTest() {
         String message = " [{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -79,7 +79,7 @@ class InitialBuildPhaseTest {
         game.getBoard().placeStreet(player, game.getBoard().getEdge("([3,1],[3,2])"));
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_ALREADY_EXISTS_ERROR.getCode());
     }
@@ -89,7 +89,7 @@ class InitialBuildPhaseTest {
         game.getBoard().placeVillage(player, game.getBoard().getNode("([2,2],[3,1],[3,2])"));
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_ALREADY_EXISTS_ERROR.getCode());
     }
@@ -99,7 +99,7 @@ class InitialBuildPhaseTest {
         game.getBoard().placeVillage(player, game.getBoard().getNode("([2,1],[2,2],[3,1])"));
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_TOO_CLOSE_TO_OTHER_STRUCTURE_ERROR.getCode());
     }

--- a/src/test/java/InitialBuildPhaseTest.java
+++ b/src/test/java/InitialBuildPhaseTest.java
@@ -29,7 +29,7 @@ class InitialBuildPhaseTest {
     void theEdgeMustExistTest() {
         // The edge is sorted incorrectly, so the test must fail
         String message = " [{ \"structure\": \"street\", \"location\": \"([3,2],[3,1])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.EDGE_DOES_NOT_EXIST_ERROR.getCode());
     }
@@ -37,7 +37,7 @@ class InitialBuildPhaseTest {
     @Test
     void theNodeMustExistTest() {
         String message = " [{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([5,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NODE_DOES_NOT_EXIST_ERROR.getCode());
     }
@@ -45,7 +45,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingNothingIsIllegalTest() {
         String message = "[]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NOT_A_VILLAGE_AND_STREET_ERROR.getCode());
     }
@@ -53,7 +53,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingTwoStreetsIsIllegalTest() {
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.NOT_A_VILLAGE_AND_STREET_ERROR.getCode());
     }
@@ -62,7 +62,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingDisconnectedStreetAndVillageIsIllegalTest() {
         String message = " [{ \"structure\": \"street\", \"location\": \"([4,1],[4,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_NOT_CONNECTED_ERROR.getCode());
     }
@@ -70,7 +70,7 @@ class InitialBuildPhaseTest {
     @Test
     void buildingConnectedStreetAndVillageIsLegalTest() {
         String message = " [{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertTrue(buildPhase.commandIsValid(player, jsonArray));
     }
 
@@ -79,7 +79,7 @@ class InitialBuildPhaseTest {
         game.getBoard().placeStreet(player, game.getBoard().getEdge("([3,1],[3,2])"));
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_ALREADY_EXISTS_ERROR.getCode());
     }
@@ -89,7 +89,7 @@ class InitialBuildPhaseTest {
         game.getBoard().placeVillage(player, game.getBoard().getNode("([2,2],[3,1],[3,2])"));
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_ALREADY_EXISTS_ERROR.getCode());
     }
@@ -99,7 +99,7 @@ class InitialBuildPhaseTest {
         game.getBoard().placeVillage(player, game.getBoard().getNode("([2,1],[2,2],[3,1])"));
 
         String message = "[{ \"structure\": \"street\", \"location\": \"([3,1],[3,2])\" }, { \"structure\": \"village\", \"location\": \"([2,2],[3,1],[3,2])\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
         assertFalse(buildPhase.commandIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.STRUCTURE_TOO_CLOSE_TO_OTHER_STRUCTURE_ERROR.getCode());
     }

--- a/src/test/java/JsonValidatorTest.java
+++ b/src/test/java/JsonValidatorTest.java
@@ -9,25 +9,25 @@ public class JsonValidatorTest {
 
     @Test
     public void testInValidJsons() {
-        assertNull(validator.getAsJsonObject("["));
-        assertNull(validator.getAsJsonObject("{}"));
-        assertNull(validator.getAsJsonObject("{ \"from\": \"stone\", \"to\": \"wood\" }, { \"from\": \"grain\", \"to\": \"stone\" }"));
-        assertNull(validator.getAsJsonObject("{ \"from\": \"stone\", \"to\": \"wood\" }, "));
-        assertNull(validator.getAsJsonObject("[ \"from\": \"stone\", \"to\": \"wood\" ] "));
-        assertNull(validator.getAsJsonObject(null));
+        assertNull(validator.getAsJsonArray("["));
+        assertNull(validator.getAsJsonArray("{}"));
+        assertNull(validator.getAsJsonArray("{ \"from\": \"stone\", \"to\": \"wood\" }, { \"from\": \"grain\", \"to\": \"stone\" }"));
+        assertNull(validator.getAsJsonArray("{ \"from\": \"stone\", \"to\": \"wood\" }, "));
+        assertNull(validator.getAsJsonArray("[ \"from\": \"stone\", \"to\": \"wood\" ] "));
+        assertNull(validator.getAsJsonArray(null));
     }
 
     @Test
     public void testValidJsons() {
-        assertEquals(validator.getAsJsonObject("[]"), new JsonArray());
-        assertEquals(validator.getAsJsonObject("    []      \n "), new JsonArray());
-        assertEquals(validator.getAsJsonObject("[{ \"from\": \"ore\", \"to\": \"wood\" }]").size(), 1);
+        assertEquals(validator.getAsJsonArray("[]"), new JsonArray());
+        assertEquals(validator.getAsJsonArray("    []      \n "), new JsonArray());
+        assertEquals(validator.getAsJsonArray("[{ \"from\": \"ore\", \"to\": \"wood\" }]").size(), 1);
     }
 
     @Test
     public void testValidOutput() {
         String message = "[{ \"structure\": \"city\", \"location\": \"([1,2],[2,1],[2,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,1])\" }]\n";
-        JsonArray array = validator.getAsJsonObject(message);
+        JsonArray array = validator.getAsJsonArray(message);
         assertEquals(array.get(0).getAsJsonObject().get("structure").getAsString(), "city");
         assertEquals(array.get(1).getAsJsonObject().get("structure").getAsString(), "street");
     }

--- a/src/test/java/JsonValidatorTest.java
+++ b/src/test/java/JsonValidatorTest.java
@@ -9,25 +9,25 @@ public class JsonValidatorTest {
 
     @Test
     public void testInValidJsons() {
-        assertNull(validator.getJsonIfValid(player, "["));
-        assertNull(validator.getJsonIfValid(player, "{}"));
-        assertNull(validator.getJsonIfValid(player, "{ \"from\": \"stone\", \"to\": \"wood\" }, { \"from\": \"grain\", \"to\": \"stone\" }"));
-        assertNull(validator.getJsonIfValid(player, "{ \"from\": \"stone\", \"to\": \"wood\" }, "));
-        assertNull(validator.getJsonIfValid(player, "[ \"from\": \"stone\", \"to\": \"wood\" ] "));
-        assertNull(validator.getJsonIfValid(player, null));
+        assertNull(validator.getAsJsonObject("["));
+        assertNull(validator.getAsJsonObject("{}"));
+        assertNull(validator.getAsJsonObject("{ \"from\": \"stone\", \"to\": \"wood\" }, { \"from\": \"grain\", \"to\": \"stone\" }"));
+        assertNull(validator.getAsJsonObject("{ \"from\": \"stone\", \"to\": \"wood\" }, "));
+        assertNull(validator.getAsJsonObject("[ \"from\": \"stone\", \"to\": \"wood\" ] "));
+        assertNull(validator.getAsJsonObject(null));
     }
 
     @Test
     public void testValidJsons() {
-        assertEquals(validator.getJsonIfValid(player, "[]"), new JsonArray());
-        assertEquals(validator.getJsonIfValid(player, "    []      \n "), new JsonArray());
-        assertEquals(validator.getJsonIfValid(player, "[{ \"from\": \"ore\", \"to\": \"wood\" }]").size(), 1);
+        assertEquals(validator.getAsJsonObject("[]"), new JsonArray());
+        assertEquals(validator.getAsJsonObject("    []      \n "), new JsonArray());
+        assertEquals(validator.getAsJsonObject("[{ \"from\": \"ore\", \"to\": \"wood\" }]").size(), 1);
     }
 
     @Test
     public void testValidOutput() {
         String message = "[{ \"structure\": \"city\", \"location\": \"([1,2],[2,1],[2,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,1])\" }]\n";
-        JsonArray array = validator.getJsonIfValid(player, message);
+        JsonArray array = validator.getAsJsonObject(message);
         assertEquals(array.get(0).getAsJsonObject().get("structure").getAsString(), "city");
         assertEquals(array.get(1).getAsJsonObject().get("structure").getAsString(), "street");
     }

--- a/src/test/java/JsonValidatorTest.java
+++ b/src/test/java/JsonValidatorTest.java
@@ -1,34 +1,55 @@
 import com.google.gson.JsonArray;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class JsonValidatorTest {
-    Player player = new Player(null,0, "tester");
-    jsonValidator validator = new jsonValidator();
-
     @Test
     public void testInValidJsons() {
-        assertNull(validator.getAsJsonArray("["));
-        assertNull(validator.getAsJsonArray("{}"));
-        assertNull(validator.getAsJsonArray("{ \"from\": \"stone\", \"to\": \"wood\" }, { \"from\": \"grain\", \"to\": \"stone\" }"));
-        assertNull(validator.getAsJsonArray("{ \"from\": \"stone\", \"to\": \"wood\" }, "));
-        assertNull(validator.getAsJsonArray("[ \"from\": \"stone\", \"to\": \"wood\" ] "));
-        assertNull(validator.getAsJsonArray(null));
+        assertNull(jsonValidator.getAsJsonArray("["));
+        assertNull(jsonValidator.getAsJsonArray("{}"));
+        assertNull(jsonValidator.getAsJsonArray("{ \"from\": \"stone\", \"to\": \"wood\" }, { \"from\": \"grain\", \"to\": \"stone\" }"));
+        assertNull(jsonValidator.getAsJsonArray("{ \"from\": \"stone\", \"to\": \"wood\" }, "));
+        assertNull(jsonValidator.getAsJsonArray("[ \"from\": \"stone\", \"to\": \"wood\" ] "));
+        assertNull(jsonValidator.getAsJsonArray(null));
     }
 
     @Test
     public void testValidJsons() {
-        assertEquals(validator.getAsJsonArray("[]"), new JsonArray());
-        assertEquals(validator.getAsJsonArray("    []      \n "), new JsonArray());
-        assertEquals(validator.getAsJsonArray("[{ \"from\": \"ore\", \"to\": \"wood\" }]").size(), 1);
+        assertEquals(jsonValidator.getAsJsonArray("[]"), new JsonArray());
+        assertEquals(jsonValidator.getAsJsonArray("    []      \n "), new JsonArray());
+        assertEquals(jsonValidator.getAsJsonArray("[{ \"from\": \"ore\", \"to\": \"wood\" }]").size(), 1);
     }
 
     @Test
     public void testValidOutput() {
         String message = "[{ \"structure\": \"city\", \"location\": \"([1,2],[2,1],[2,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,1])\" }]\n";
-        JsonArray array = validator.getAsJsonArray(message);
+        JsonArray array = jsonValidator.getAsJsonArray(message);
         assertEquals(array.get(0).getAsJsonObject().get("structure").getAsString(), "city");
         assertEquals(array.get(1).getAsJsonObject().get("structure").getAsString(), "street");
+    }
+
+    @Test
+    public void testValidation() {
+        String message = "[{ \"structure\": \"city\", \"location\": \"([1,2],[2,1],[2,2])\" }, { \"structure\": \"street\", \"location\": \"([2,2],[3,1])\" }]\n";
+        HashMap<String, ValidationType> props = new HashMap<>() {{
+            put("structure", ValidationType.STRUCTURE);
+            put("location", ValidationType.STRING);
+        }};
+        assertNotNull(jsonValidator.getJsonObjectIfCorrect(message, props));
+
+        // incorrect message (street is misspelled and is thus not a structure)
+        message = "[{ \"structure\": \"city\", \"location\": \"([1,2],[2,1],[2,2])\" }, { \"structure\": \"stret\", \"location\": \"([2,2],[3,1])\" }]\n";
+        assertNull(jsonValidator.getJsonObjectIfCorrect(message, props));
+
+        // incorrect message (structure key is misspelled while it is expected)
+        message = "[{ \"structure\": \"city\", \"location\": \"([1,2],[2,1],[2,2])\" }, { \"structre\": \"street\", \"location\": \"([2,2],[3,1])\" }]\n";
+        assertNull(jsonValidator.getJsonObjectIfCorrect(message, props));
+
+        // incorrect message (child misses a field)
+        message = "[{ \"structure\": \"city\", \"location\": \"([1,2],[2,1],[2,2])\" }, { \"structre\": \"street\"}]\n";
+        assertNull(jsonValidator.getJsonObjectIfCorrect(message, props));
     }
 }

--- a/src/test/java/MoveBanditPhaseTest.java
+++ b/src/test/java/MoveBanditPhaseTest.java
@@ -38,7 +38,7 @@ class MoveBanditPhaseTest {
         String message = "[{}]";
         JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
         assertFalse(moveBanditPhase.moveIsValid(jsonArray));
-        assertEquals(game.getLastResponse().getCode(), Constants.INVALID_BANDIT_MOVE_ERROR.getCode());
+        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
     }
 
     @Test
@@ -46,7 +46,7 @@ class MoveBanditPhaseTest {
         String message = "[{loc: \"\"}]";
         JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
         assertFalse(moveBanditPhase.moveIsValid(jsonArray));
-        assertEquals(game.getLastResponse().getCode(), Constants.INVALID_BANDIT_MOVE_ERROR.getCode());
+        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
     }
 
     @Test
@@ -54,7 +54,7 @@ class MoveBanditPhaseTest {
         String message = "[{ \"location\": {} }]";
         JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
         assertFalse(moveBanditPhase.moveIsValid(jsonArray));
-        assertEquals(game.getLastResponse().getCode(), Constants.INVALID_BANDIT_MOVE_ERROR.getCode());
+        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
 
         message = "[{ \"location\": \"foo\" }]";
         jsonArray = new jsonValidator().getJsonIfValid(player, message);

--- a/src/test/java/MoveBanditPhaseTest.java
+++ b/src/test/java/MoveBanditPhaseTest.java
@@ -42,6 +42,14 @@ class MoveBanditPhaseTest {
     }
 
     @Test
+    void requiresAPoperLocationKeuTest() {
+        String message = "[{loc: \"\"}]";
+        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        assertFalse(moveBanditPhase.moveIsValid(jsonArray));
+        assertEquals(game.getLastResponse().getCode(), Constants.INVALID_BANDIT_MOVE_ERROR.getCode());
+    }
+
+    @Test
     void requiresAValidLocationValueTest() {
         String message = "[{ \"location\": {} }]";
         JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);

--- a/src/test/java/MoveBanditPhaseTest.java
+++ b/src/test/java/MoveBanditPhaseTest.java
@@ -27,45 +27,45 @@ class MoveBanditPhaseTest {
     @Test
     void playerCanPlaceBanditOnTile() {
         String message = "[{ \"location\": \"" + game.getBoard().getTilesForDiceNumber(8).get(0).getKey() + "\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertTrue(moveBanditPhase.moveIsValid(jsonArray));
         moveBanditPhase.move(player, jsonArray);
         assertEquals(game.getLastResponse().getCode(), Constants.OK.getCode());
     }
-
-    @Test
-    void requiresALocationValueTest() {
-        String message = "[{}]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
-        assertFalse(moveBanditPhase.moveIsValid(jsonArray));
-        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
-    }
-
-    @Test
-    void requiresAPoperLocationKeuTest() {
-        String message = "[{loc: \"\"}]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
-        assertFalse(moveBanditPhase.moveIsValid(jsonArray));
-        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
-    }
-
-    @Test
-    void requiresAValidLocationValueTest() {
-        String message = "[{ \"location\": {} }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
-        assertFalse(moveBanditPhase.moveIsValid(jsonArray));
-        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
-
-        message = "[{ \"location\": \"foo\" }]";
-        jsonArray = new jsonValidator().getJsonIfValid(player, message);
-        assertFalse(moveBanditPhase.moveIsValid(jsonArray));
-        assertEquals(game.getLastResponse().getCode(), Constants.INVALID_BANDIT_MOVE_ERROR.getCode());
-    }
+//
+//    @Test
+//    void requiresALocationValueTest() {
+//        String message = "[{}]";
+//        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+//        assertFalse(moveBanditPhase.moveIsValid(jsonArray));
+//        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
+//    }
+//
+//    @Test
+//    void requiresAPoperLocationKeuTest() {
+//        String message = "[{loc: \"\"}]";
+//        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+//        assertFalse(moveBanditPhase.moveIsValid(jsonArray));
+//        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
+//    }
+//
+//    @Test
+//    void requiresAValidLocationValueTest() {
+//        String message = "[{ \"location\": {} }]";
+//        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+//        assertFalse(moveBanditPhase.moveIsValid(jsonArray));
+//        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
+//
+//        message = "[{ \"location\": \"foo\" }]";
+//        jsonArray = jsonValidator.getAsJsonObject(message);
+//        assertFalse(moveBanditPhase.moveIsValid(jsonArray));
+//        assertEquals(game.getLastResponse().getCode(), Constants.INVALID_BANDIT_MOVE_ERROR.getCode());
+//    }
 
     @Test
     void playerCannotPlaceBanditOnSeaTile() {
         String message = "[{ \"location\": \"" + game.getBoard().getTiles().get(0).getKey() + "\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertFalse(moveBanditPhase.moveIsValid(jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CAN_NOT_PLACE_BANDIT_ON_SEA_TILE_ERROR.getCode());
     }
@@ -73,7 +73,7 @@ class MoveBanditPhaseTest {
     @Test
     void playerCannotPlaceBanditOnSameTile() {
         String message = "[{ \"location\": \"" + game.getBoard().getBandit().getTile().getKey() + "\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertFalse(moveBanditPhase.moveIsValid(jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CAN_NOT_PLACE_BANDIT_ON_SAME_TILE_ERROR.getCode());
     }

--- a/src/test/java/MoveBanditPhaseTest.java
+++ b/src/test/java/MoveBanditPhaseTest.java
@@ -27,7 +27,7 @@ class MoveBanditPhaseTest {
     @Test
     void playerCanPlaceBanditOnTile() {
         String message = "[{ \"location\": \"" + game.getBoard().getTilesForDiceNumber(8).get(0).getKey() + "\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(moveBanditPhase.moveIsValid(jsonArray));
         moveBanditPhase.move(player, jsonArray);
         assertEquals(game.getLastResponse().getCode(), Constants.OK.getCode());
@@ -65,7 +65,7 @@ class MoveBanditPhaseTest {
     @Test
     void playerCannotPlaceBanditOnSeaTile() {
         String message = "[{ \"location\": \"" + game.getBoard().getTiles().get(0).getKey() + "\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(moveBanditPhase.moveIsValid(jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CAN_NOT_PLACE_BANDIT_ON_SEA_TILE_ERROR.getCode());
     }
@@ -73,7 +73,7 @@ class MoveBanditPhaseTest {
     @Test
     void playerCannotPlaceBanditOnSameTile() {
         String message = "[{ \"location\": \"" + game.getBoard().getBandit().getTile().getKey() + "\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(moveBanditPhase.moveIsValid(jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.CAN_NOT_PLACE_BANDIT_ON_SAME_TILE_ERROR.getCode());
     }

--- a/src/test/java/PlayerTest.java
+++ b/src/test/java/PlayerTest.java
@@ -85,7 +85,7 @@ public class PlayerTest {
     void getResourcesAsJsonStringTest() {
         player.addResources(Constants.STREET_COSTS);
         String jsonString = Helpers.getJSONArrayFromHashMap(player.getResources(), "type", "value");
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(jsonString);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(jsonString);
         assertNotNull(jsonArray);
         for (JsonElement element : jsonArray) {
             String typename = element.getAsJsonObject().get("type").getAsString();

--- a/src/test/java/PlayerTest.java
+++ b/src/test/java/PlayerTest.java
@@ -85,7 +85,7 @@ public class PlayerTest {
     void getResourcesAsJsonStringTest() {
         player.addResources(Constants.STREET_COSTS);
         String jsonString = Helpers.getJSONArrayFromHashMap(player.getResources(), "type", "value");
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(jsonString);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(jsonString);
         assertNotNull(jsonArray);
         for (JsonElement element : jsonArray) {
             String typename = element.getAsJsonObject().get("type").getAsString();

--- a/src/test/java/PlayerTest.java
+++ b/src/test/java/PlayerTest.java
@@ -85,7 +85,7 @@ public class PlayerTest {
     void getResourcesAsJsonStringTest() {
         player.addResources(Constants.STREET_COSTS);
         String jsonString = Helpers.getJSONArrayFromHashMap(player.getResources(), "type", "value");
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, jsonString);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(jsonString);
         assertNotNull(jsonArray);
         for (JsonElement element : jsonArray) {
             String typename = element.getAsJsonObject().get("type").getAsString();

--- a/src/test/java/TradePhaseTest.java
+++ b/src/test/java/TradePhaseTest.java
@@ -133,7 +133,7 @@ public class TradePhaseTest {
         // set up a trade of 3 ore to wood
         player.addResources(Resource.ORE, 3);
         String message = "[{ \"from\": \"ore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
 
         // the trade should initially not be legal
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));

--- a/src/test/java/TradePhaseTest.java
+++ b/src/test/java/TradePhaseTest.java
@@ -12,7 +12,7 @@ public class TradePhaseTest {
     @Test
     public void testTradingNothing() {
         String message = "[]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(tradePhase.tradeIsValid(player, jsonArray));
     }
 
@@ -22,7 +22,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 4);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(tradePhase.tradeIsValid(player, jsonArray));
     }
 
@@ -39,7 +39,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 3);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"stone\" }, { \"from\": \"grain\", \"to\": \"ore\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertTrue(tradePhase.tradeIsValid(player, jsonArray));
     }
 
@@ -50,7 +50,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 3);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"stone\" }, { \"from\": \"grain\", \"to\": \"ore\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -61,7 +61,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 3);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -72,7 +72,7 @@ public class TradePhaseTest {
         player.addResources(Resource.GRAIN, 7);
 
         String message = "[{ \"from\": \"grain\", \"to\": \"wood\" }, { \"from\": \"grain\", \"to\": \"ore\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -83,7 +83,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 4);
 
         String message = "[{ \"from\": \"lore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INVALID_TRADE_ERROR.getCode());
     }
@@ -105,7 +105,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 4);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
 
         tradePhase.trade(player, jsonArray);
 
@@ -133,7 +133,7 @@ public class TradePhaseTest {
         // set up a trade of 3 ore to wood
         player.addResources(Resource.ORE, 3);
         String message = "[{ \"from\": \"ore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonArray(message);
 
         // the trade should initially not be legal
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
@@ -169,7 +169,7 @@ public class TradePhaseTest {
         // set up a trade of 2 stone to wood
         player.addResources(Resource.STONE, 2);
         String message = "[{ \"from\": \"stone\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+        JsonArray jsonArray = jsonValidator.getAsJsonArray(message);
 
         // the trade should initially not be legal
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));

--- a/src/test/java/TradePhaseTest.java
+++ b/src/test/java/TradePhaseTest.java
@@ -96,7 +96,7 @@ public class TradePhaseTest {
         String message = "[{ \"form\": \"lore\", \"to\": \"wood\" }]";
         JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
-        assertEquals(game.getLastResponse().getCode(), Constants.INVALID_TRADE_ERROR.getCode());
+        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
     }
 
     @Test

--- a/src/test/java/TradePhaseTest.java
+++ b/src/test/java/TradePhaseTest.java
@@ -12,7 +12,7 @@ public class TradePhaseTest {
     @Test
     public void testTradingNothing() {
         String message = "[]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertTrue(tradePhase.tradeIsValid(player, jsonArray));
     }
 
@@ -22,7 +22,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 4);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertTrue(tradePhase.tradeIsValid(player, jsonArray));
     }
 
@@ -39,7 +39,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 3);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"stone\" }, { \"from\": \"grain\", \"to\": \"ore\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertTrue(tradePhase.tradeIsValid(player, jsonArray));
     }
 
@@ -50,7 +50,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 3);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"stone\" }, { \"from\": \"grain\", \"to\": \"ore\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -61,7 +61,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 3);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -72,7 +72,7 @@ public class TradePhaseTest {
         player.addResources(Resource.GRAIN, 7);
 
         String message = "[{ \"from\": \"grain\", \"to\": \"wood\" }, { \"from\": \"grain\", \"to\": \"ore\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INSUFFICIENT_RESOURCES_ERROR.getCode());
     }
@@ -83,21 +83,21 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 4);
 
         String message = "[{ \"from\": \"lore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
         assertEquals(game.getLastResponse().getCode(), Constants.INVALID_TRADE_ERROR.getCode());
     }
 
-    @Test
-    public void testWithInvalidJsonKey() {
-        game.setCurrentPlayer(player);
-        player.addResources(Resource.ORE, 4);
-
-        String message = "[{ \"form\": \"lore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
-        assertFalse(tradePhase.tradeIsValid(player, jsonArray));
-        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
-    }
+//    @Test
+//    public void testWithInvalidJsonKey() {
+//        game.setCurrentPlayer(player);
+//        player.addResources(Resource.ORE, 4);
+//
+//        String message = "[{ \"form\": \"lore\", \"to\": \"wood\" }]";
+//        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
+//        assertFalse(tradePhase.tradeIsValid(player, jsonArray));
+//        assertEquals(game.getLastResponse().getCode(), Constants.MALFORMED_JSON_ERROR.getCode());
+//    }
 
     @Test
     public void testTradingOnBoard() {
@@ -105,7 +105,7 @@ public class TradePhaseTest {
         player.addResources(Resource.ORE, 4);
 
         String message = "[{ \"from\": \"ore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
 
         tradePhase.trade(player, jsonArray);
 
@@ -133,7 +133,7 @@ public class TradePhaseTest {
         // set up a trade of 3 ore to wood
         player.addResources(Resource.ORE, 3);
         String message = "[{ \"from\": \"ore\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = new jsonValidator().getAsJsonObject(message);
 
         // the trade should initially not be legal
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));
@@ -169,7 +169,7 @@ public class TradePhaseTest {
         // set up a trade of 2 stone to wood
         player.addResources(Resource.STONE, 2);
         String message = "[{ \"from\": \"stone\", \"to\": \"wood\" }]";
-        JsonArray jsonArray = new jsonValidator().getJsonIfValid(player, message);
+        JsonArray jsonArray = jsonValidator.getAsJsonObject(message);
 
         // the trade should initially not be legal
         assertFalse(tradePhase.tradeIsValid(player, jsonArray));


### PR DESCRIPTION
During testing the web interface I noticed that the server crashes quite often. I noticed that the incoming JSON message where mostly validated for complying with the Catan rules, but there was not much validation to determine if  the received message is of the desired format. 

This PR introduces some jsonvalidator helpers that allow us to specify what keys we expect in a message, and what types these should have. Therefore it is easy to catch incorrect messages and after that the rule validations should suffice. 

JsonValidator now accepts a set of properties that it expects messages to have. for example:

```
    HashMap<String, ValidationType> props = new HashMap<>() {{
        put("from", ValidationType.RESOURCE);
        put("to", ValidationType.RESOURCE);
    }};

  // expects only messages like:
  {
   "to": "grain", // or other resource
   "from": "wool", // or other resource
  }

  // will reject messages like: 
  {
   "too": "grain", // or other resource
   "from": "wool", // or other resource
  }
  // (inccorrect resource)
  {
   "to": "test", // or other resource
   "from": "wool", // or other resource
  }
  // (incorrect resource)
  {
   "to": "", // or other resource
   "from": "wool", // or other resource
  }
  // (no resource value)
  {
   "to": , // or other resource
   "from": "wool", // or other resource
  }
  // (not all keys present)
  {
   "to": "grain", // or other resource
  }
```
Which indicates that only messages where `from` and `to` are present as keys and where their values are resources.  This is implemented for all primitive types, and also for resources and structures. Edges need more work and will be done in an upcoming PR (#20) . Using this method saves a lot of null checking in the `*-Phase` classes, and decouples the catan rule validations with the json format validations. 